### PR TITLE
Update Messenger

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ the `Intercom` component.
 <details>
 <summary>Messenger</summary>
 
-To use Messenger, import the `LiveChatLoaderProvider` and then set the `provider` prop as `messenger`, the `providerKey` prop as your Facebook Page ID.
+To use Messenger, import the `LiveChatLoaderProvider` and then set the `provider` prop as `messenger` and the `providerKey` prop as your Facebook Page ID.
 
-In addition, you can set an optional `locale` prop, and the default value is `en_US`.
+You can optionally set the `locale` prop, the default value is `en_US`.
 
 Then import the `Messenger` component.
 
@@ -202,7 +202,11 @@ import { LiveChatLoaderProvider, Messenger } from 'react-live-chat-loader'
 export default class App extends React.Component {
   render() {
     return (
-      <LiveChatLoaderProvider provider="messenger" providerKey="111222333444555" locale="en_US">
+      <LiveChatLoaderProvider
+        provider="messenger"
+        providerKey="111222333444555"
+        locale="en_US"
+      >
         /* ... */
         <Messenger />
       </LiveChatLoaderProvider>
@@ -213,35 +217,23 @@ export default class App extends React.Component {
 
 For a list of locale option values, refer to [Facebook Localization documentation](https://developers.facebook.com/docs/internationalization).
 
-if you are using other facebook features like share, you should set the `appID` prop as your Facebook App ID since customer chat SDK includes all features that facebook provide.
+If you are using other Facebook features like share, you should set the `appID` prop as your Facebook App ID as the Customer Chat SDK includes all the features that Facebook provide.
 
-You can customize your customer chat plugin as well, we recommend the `themeColor` you set to `Messenger` should be same as `themeColor` you set to `LiveChatLoaderProvider`.
+You can customise the Messenger widget by passing the following props to the
+`Messenger` component:
 
-```jsx
-import { LiveChatLoaderProvider, Messenger } from 'react-live-chat-loader'
+- `color`: The theme color of the widget
+- `loggedInGreeting`: The greeting text that will be displayed if the user is currently logged in to Facebook.
+- `loggedOutGreeting`: The greeting text that will be displayed if the user is
+  currently not logged in to Facebook.
+- `greetingDialogDisplay`: Sets how the greeting dialog will be displayed.
+- `greetingDialogDelay`: Sets the number of seconds of delay before the greeting dialog is shown after the plugin is loaded.
 
-export default class App extends React.Component {
-  render() {
-    return (
-      <LiveChatLoaderProvider 
-        provider="messenger" 
-        providerKey="111222333444555" 
-        appID="1111222233334444"
-        themeColor="#40D058"
-        loggedInGreeting="Welcome"
-        loggedOutGreeting="Please sign in"
-        greetingDialogDisplay="hide"
-        greetingDialogDelay="0"
-        >
-        /* ... */
-        <Messenger themeColor="#40D058" />
-      </LiveChatLoaderProvider>
-    )
-  }
-}
-```
+For a list of options, refer to [Facebook Customer Chat Plugin documentation](https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin#customization).
 
-For a list of optional customizations, refer to [Facebook Customer Chat Plugin documentation](https://developers.facebook.com/docs/messenger-platform/discovery/customer-chat-plugin#customization).
+**Please note**: Facebook Messenger will not load on localhost and you will need
+to configure your domain through the setup wizard in Facebook for it to load
+correctly.
 
 </details>
 

--- a/src/components/Messenger/index.js
+++ b/src/components/Messenger/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { useChat } from '../../'
+import { useChat, useProvider } from '../../'
 import STATES from '../../utils/states'
 
 const styles = {
@@ -24,12 +24,37 @@ const styles = {
     outline: 'none',
     userSelect: 'none'
   }
-};
+}
 
-const Messenger = ({ themeColor }) => {
-  const [state, loadChat] = useChat({ loadWhenIdle: true });
+const CustomerChat = ({
+  color,
+  loggedInGreeting,
+  loggedOutGreeting,
+  greetingDialogDisplay,
+  greetingDialogDelay,
+  ref
+}) => {
+  const { providerKey } = useProvider()
 
-  if (state === STATES.COMPLETE) return null;
+  return (
+    <div
+      className="fb-customerchat"
+      attribution="react-live-chat-loader"
+      page_id={providerKey}
+      theme_color={color}
+      logged_in_greeting={loggedInGreeting}
+      logged_out_greeting={loggedOutGreeting}
+      greeting_dialog_display={greetingDialogDisplay}
+      greeting_dialog_delay={greetingDialogDelay}
+      ref={ref || 'react-live-chat-loader'}
+    ></div>
+  )
+}
+
+const Widget = ({ color }) => {
+  const [state, loadChat] = useChat({ loadWhenIdle: true })
+
+  if (state === STATES.COMPLETE) return null
 
   return (
     <div
@@ -40,14 +65,20 @@ const Messenger = ({ themeColor }) => {
       <svg width="60px" height="60px" viewBox="0 0 60 60">
         <svg x="0" y="0" width="60px" height="60px">
           <defs>
-            <linearGradient x1="50%" y1="0%" x2="50%" y2="100%" id="linearGradient-1">
+            <linearGradient
+              x1="50%"
+              y1="0%"
+              x2="50%"
+              y2="100%"
+              id="linearGradient-1"
+            >
               <stop stopColor="#00B2FF" offset="0%" />
               <stop stopColor="#006AFF" offset="100%" />
             </linearGradient>
           </defs>
           <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
             <g>
-              <circle fill={themeColor ? themeColor : "#FFFFFF"} cx="30" cy="30" r="30" />
+              <circle fill={color ? color : '#FFFFFF'} cx="30" cy="30" r="30" />
               <svg x="10" y="10">
                 <g>
                   <rect id="container" x="0" y="0" width="40" height="40" />
@@ -55,12 +86,12 @@ const Messenger = ({ themeColor }) => {
                     <path
                       d="M20,0 C8.7334,0 0,8.2528 0,19.4 C0,25.2307 2.3896,30.2691 6.2811,33.7492 C6.6078,34.0414 6.805,34.4513 6.8184,34.8894 L6.9273,38.4474 C6.9621,39.5819 8.1343,40.3205 9.1727,39.8621 L13.1424,38.1098 C13.4789,37.9612 13.856,37.9335 14.2106,38.0311 C16.0348,38.5327 17.9763,38.8 20,38.8 C31.2666,38.8 40,30.5472 40,19.4 C40,8.2528 31.2666,0 20,0"
                       id="bubble"
-                      fill={themeColor ? "#FFFFFF" : "url(#linearGradient-1)"}
+                      fill={color ? '#FFFFFF' : 'url(#linearGradient-1)'}
                     />
                     <path
                       d="M7.99009,25.07344 L13.86509,15.75264 C14.79959,14.26984 16.80079,13.90064 18.20299,14.95224 L22.87569,18.45674 C23.30439,18.77834 23.89429,18.77664 24.32119,18.45264 L30.63189,13.66324 C31.47419,13.02404 32.57369,14.03204 32.00999,14.92654 L26.13499,24.24744 C25.20039,25.73014 23.19919,26.09944 21.79709,25.04774 L17.12429,21.54314 C16.69559,21.22164 16.10569,21.22334 15.67879,21.54734 L9.36809,26.33674 C8.52579,26.97594 7.42629,25.96794 7.99009,25.07344"
                       id="bolt"
-                      fill={themeColor ? themeColor : "#FFFFFF"}
+                      fill={color ? color : '#FFFFFF'}
                     />
                   </g>
                 </g>
@@ -70,11 +101,18 @@ const Messenger = ({ themeColor }) => {
         </svg>
       </svg>
     </div>
-  );
-};
+  )
+}
+
+const Messenger = ({ color, ...props }) => (
+  <>
+    <CustomerChat color={color} {...props} />
+    <Widget color={color} />
+  </>
+)
 
 Messenger.defaultProps = {
-  themeColor: ''
+  color: ''
 }
 
 export default Messenger

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -14,7 +14,7 @@ const connection =
 let scriptLoaded = false
 
 const useChat = ({ loadWhenIdle } = {}) => {
-  const { provider, providerKey, idlePeriod, state, setState, ...option } = useContext(
+  const { provider, providerKey, idlePeriod, state, setState } = useContext(
     LiveChatLoaderContext
   )
 
@@ -78,7 +78,7 @@ const useChat = ({ loadWhenIdle } = {}) => {
 
     if (!scriptLoaded) {
       scriptLoaded = true
-      chatProvider.load({ providerKey, state, setState, ...option })
+      chatProvider.load({ providerKey, state, setState })
       setTimeout(() => setState(STATES.COMPLETE), 2000)
     }
 

--- a/src/hooks/useProvider.js
+++ b/src/hooks/useProvider.js
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+
+import { LiveChatLoaderContext } from '../'
+
+const useProvider = () => {
+  const { provider, providerKey } = useContext(LiveChatLoaderContext)
+
+  return { provider, providerKey }
+}
+
+export default useProvider

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ LiveChatLoaderProvider.defaultProps = {
 }
 
 export { default as useChat } from './hooks/useChat'
+export { default as useProvider } from './hooks/useProvider'
 export { default as HelpScout } from './components/HelpScout'
 export { default as Intercom } from './components/Intercom'
 export { default as Messenger } from './components/Messenger'

--- a/src/providers/messenger.js
+++ b/src/providers/messenger.js
@@ -1,64 +1,46 @@
 const domain = 'https://connect.facebook.net'
 
-const createCustomerchat = ({ 
-  providerKey,
-  themeColor = '',
-  loggedInGreeting = '',
-  loggedOutGreeting = '',
-  greetingDialogDisplay = '',
-  greetingDialogDelay = '',
-}) => {
-  if(!document.querySelector('.fb-customerchat')) {
-    const chat = window.document.createElement('div');
-    chat.className = "fb-customerchat";
-    chat.setAttribute("page_id", providerKey);
-    if(themeColor) chat.setAttribute('theme_color', themeColor);
-    if(loggedInGreeting) chat.setAttribute('logged_in_greeting', loggedInGreeting);
-    if(loggedOutGreeting) chat.setAttribute('logged_out_greeting', loggedOutGreeting);
-    if(greetingDialogDisplay) chat.setAttribute('greeting_dialog_display', greetingDialogDisplay);
-    if(greetingDialogDelay) chat.setAttribute('greeting_dialog_delay', greetingDialogDelay);
-    window.document.body.appendChild(chat);
-  }
-}
-
-const loadScript = ({ locale = 'en_US', ...options }) => {
+const loadScript = ({ locale }) => {
   if (window.FB) return
 
   !(function loadFacebookSDK(d, s, id) {
-    // create customerchat
-    createCustomerchat(options);
     // fetch customerchat.js
-    var fjs = d.getElementsByTagName(s)[0];
+    var fjs = d.getElementsByTagName(s)[0]
     if (d.getElementById(id)) {
-      return;
+      return
     }
-    var js = d.createElement(s);
-    js.id = id;
-    js.src = `${domain}/${locale}/sdk/xfbml.customerchat.js`;
+    var js = d.createElement(s)
+    js.id = id
+    js.src = `${domain}/${locale}/sdk/xfbml.customerchat.js`
     if (fjs) {
-      fjs.parentNode.insertBefore(js, fjs);
+      fjs.parentNode.insertBefore(js, fjs)
     } else {
-      d.body.appendChild(js);
+      d.body.appendChild(js)
     }
-  })(window.document, 'script', 'facebook-jssdk');
+  })(window.document, 'script', 'facebook-jssdk')
 }
 
-const load = ({ appID, ...options }) => {
-  loadScript(options);
+const load = ({ appID, locale = 'en_US' }) => {
+  loadScript({ locale })
   window.fbAsyncInit = function() {
-    window.FB.init(Object.assign({
-      cookie: true,
-      xfbml: true,
-      version: 'v6.0'
-    }, appID ? { appId: appID } : {}));
-  };
+    window.FB.init(
+      Object.assign(
+        {
+          cookie: true,
+          xfbml: true,
+          version: 'v6.0'
+        },
+        appID ? { appId: appID } : {}
+      )
+    )
+  }
 }
 
 const open = () => {
-  window.FB.CustomerChat.show(false);
+  window.FB.CustomerChat.show(false)
 }
 const close = () => {
-  window.FB.CustomerChat.hide();
+  window.FB.CustomerChat.hide()
 }
 
 export default {

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -3,7 +3,13 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { text } from '@storybook/addon-knobs'
 
-import { LiveChatLoaderProvider, HelpScout, Intercom, Messenger, useChat } from '../src'
+import {
+  LiveChatLoaderProvider,
+  HelpScout,
+  Intercom,
+  Messenger,
+  useChat
+} from '../src'
 
 const Button = () => {
   const [state, loadChat] = useChat()
@@ -69,33 +75,5 @@ storiesOf('Intercom', module)
   )
 
 storiesOf('Messenger', module)
-  .add('Chat', () => (
-    <LiveChatLoaderProvider 
-      provider="messenger" 
-      providerKey="111222333444555"
-      // the following is optional 
-      appID="1111222233334444"
-      locale="zh_TW"
-      themeColor="#40D058"
-      loggedInGreeting="Welcome"
-      loggedOutGreeting="Please sign in"
-      greetingDialogDisplay="hide"
-      greetingDialogDelay="0"
-      >
-      <Messenger themeColor="#40D058" />
-      <Button />
-    </LiveChatLoaderProvider>
-  ))
-  .add('hook', () =>
-    React.createElement(() => {
-      return (
-        <LiveChatLoaderProvider
-          provider="messenger"
-          providerKey="111222333444555"
-          idlePeriod={0}
-        >
-          <Button />
-        </LiveChatLoaderProvider>
-      )
-    })
-  )
+  .add('Chat', () => <div>Messenger will not load on localhost.</div>)
+  .add('hook', () => <div>Messenger will not load on localhost.</div>)


### PR DESCRIPTION
Following on from #11 this PR refactors Messenger to accept display props on the Messenger component.

- Messenger now accepts all display props on the Messenger component.
- The Messenger component now renders the `fb-customerchat` div.
- `themeColor` has been changed to `color` to make it consistent with
  the other widgets