### PR TITLE
Missing props from LiveChatLoaderContext to messenger provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ the `Intercom` component.
 
 To use Messenger, import the `LiveChatLoaderProvider` and then set the `provider` prop as `messenger` and the `providerKey` prop as your Facebook Page ID.
 
+If you are using other Facebook features like share, you should set the `appID` prop as your Facebook App ID as the Customer Chat SDK includes all the features that Facebook provide.
+
 You can optionally set the `locale` prop, the default value is `en_US`.
 
 Then import the `Messenger` component.
@@ -208,6 +210,7 @@ export default class App extends React.Component {
       <LiveChatLoaderProvider
         provider="messenger"
         providerKey="111222333444555"
+        appID="111222333444555"
         locale="en_US"
       >
         /* ... */
@@ -219,8 +222,6 @@ export default class App extends React.Component {
 ```
 
 For a list of locale option values, refer to [Facebook Localization documentation](https://developers.facebook.com/docs/internationalization).
-
-If you are using other Facebook features like share, you should set the `appID` prop as your Facebook App ID as the Customer Chat SDK includes all the features that Facebook provide.
 
 You can customise the Messenger widget by passing the following props to the
 `Messenger` component:

--- a/src/hooks/useChat.js
+++ b/src/hooks/useChat.js
@@ -14,7 +14,7 @@ const connection =
 let scriptLoaded = false
 
 const useChat = ({ loadWhenIdle } = {}) => {
-  const { provider, providerKey, idlePeriod, state, setState } = useContext(
+  const { provider, providerKey, idlePeriod, state, setState, ...options } = useContext(
     LiveChatLoaderContext
   )
 
@@ -78,7 +78,7 @@ const useChat = ({ loadWhenIdle } = {}) => {
 
     if (!scriptLoaded) {
       scriptLoaded = true
-      chatProvider.load({ providerKey, state, setState })
+      chatProvider.load({ providerKey, state, setState, ...options })
       setTimeout(() => setState(STATES.COMPLETE), 2000)
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Requiring additional props from `LiveChat LoaderContext` in `useChat`, and use it to load messenger provider

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
N/A

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested it on my own project, using chrome developer tools to check if the correct version of Customer Chat SDK is downloaded or not

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.