### PR TITLE
Update README: Example pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,15 +389,11 @@ Add your new provider to this README under [Supported Providers](#supported-prov
 
 #### 4. Add an example page
 
-Add a new page to `website/pages/` which showcases the provider. If you don't
-want to include your `providerKey` leave this blank and the maintainers will set
-one up.
+Add a new page to `website/pages/` which showcases the provider. If you don't want to include your `providerKey` leave this blank and the maintainers will set one up.
 
-The new provider page can be tested locally by creating a distribution version
-of the package and referencing this from the `wesbite`.
+The new provider page can be tested locally by creating a distribution version of the package and referencing this from the `wesbite`.
 
-Unfortunately if you try to include the package locally from source you'll most likely run
-into a [Duplicate React](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) error.
+Unfortunately if you try to include the package locally from source you'll most likely run into a [Duplicate React](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) error.
 
 To create the distribution version and reference it, do the following:
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,28 @@ Export the component from `src/index.js`
 
 Add your new provider to this README under [Supported Providers](#supported-providers).
 
+#### 4. Add an example page
+
+Add a new page to `website/pages/` which showcases the provider. If you don't
+want to include your `providerKey` leave this blank and the maintainers will set
+one up.
+
+The new provider page can be tested locally by creating a distribution version
+of the package and referencing this from the `wesbite`.
+
+Unfortunately if you try to include the package locally from source you'll most likely run
+into a [Duplicate React](https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react) error.
+
+To create the distribution version and reference it, do the following:
+
+- In the root of the project, run `yarn build` to build the package into `dist`
+- Update `website/package.json` to reference the `dist` build: `"react-live-chat-loader": "../dist"`
+- In the `website` directory run `npm install`
+- In the `website` directory run the server with `npm run dev`
+- Add a new page to `website/pages/` which includes the new component
+- Add a link to the provider in `website/pages/index.js`
+- Add a link to the provider in `website/components/exampleLinks.js`
+
 ## Examples
 
 - [react-live-chat-loader-example-app](https://github.com/calibreapp/react-live-chat-loader/tree/master/website): example [Next.js](https://nextjs.org) application


### PR DESCRIPTION
This PR updates the README with instructions on how to add an example page for a provider and includes details on how to test it locally from a distribution build.