### PR TITLE
Add Default Params For useChat Hook

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -13,11 +13,13 @@ const connection =
 
 let scriptLoaded = false
 
-const useChat = ({
-  loadWhenIdle
-}: {
-  loadWhenIdle: boolean
-}): [State, ({ open }: { open: boolean }) => void] => {
+const useChat = (
+  {
+    loadWhenIdle
+  }: {
+    loadWhenIdle: boolean
+  } = { loadWhenIdle: true }
+): [State, ({ open }: { open: boolean }) => void] => {
   const {
     provider,
     providerKey,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -18,7 +18,7 @@ const useChat = (
     loadWhenIdle
   }: {
     loadWhenIdle: boolean
-  } = { loadWhenIdle: true }
+  } = { loadWhenIdle: false }
 ): [State, ({ open }: { open: boolean }) => void] => {
   const {
     provider,


### PR DESCRIPTION
## Comments:
Related to [this issue](https://github.com/calibreapp/react-live-chat-loader/issues/62).

@mikedijkstra let me know if you'd prefer this instead:
```ts
const useChat = ({
  loadWhenIdle = false 
}: { loadWhenIdle: boolean }): [State, ({ open }: { open: boolean }) => void] => {
```

## Commits:
- 22e2830 Add default param for useChat hook.
