### PR TITLE
Bundle Type Definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ import { useChat } from 'react-live-chat-loader'
 export const LoadChatButton = () => {
   const [state, loadChat] = useChat()
 
-  return <button onClick={loadChat}>Load Chat</button>
+  return <button onClick={() => loadChat({ open: true })}>Load Chat</button>
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-live-chat-loader",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
-    "build": "npm run lint && tsc && babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline",
+    "build": "npm run lint && tsc --emitDeclarationOnly && babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "dev": "tsc --noEmit --watch"

--- a/src/components/LiveChatLoaderProvider.tsx
+++ b/src/components/LiveChatLoaderProvider.tsx
@@ -13,7 +13,7 @@ export const LiveChatLoaderProvider = ({
   children: JSX.Element
   idlePeriod?: number
   providerKey: string
-  appID: string
+  appID?: string
 }): JSX.Element | null => {
   const [state, setState] = useState<State>('initial')
   const value = {

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,9 +4,9 @@ import { Provider, State } from 'types'
 interface Context {
   provider: Provider
   providerKey: string
-  appID: string
   state: State
   setState: (state: State) => void
+  appID?: string
   locale?: string
   idlePeriod?: number
 }

--- a/src/providers/messenger.ts
+++ b/src/providers/messenger.ts
@@ -37,7 +37,7 @@ const load = ({
   locale = 'en_US',
   setState
 }: {
-  appID: string
+  appID?: string
   locale?: string
   setState: (state: State) => void
 }): void => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,10 @@
     "isolatedModules": true,
     "jsx": "react",
     "moduleResolution": "node",
-    "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
-    "strict": true
+    "strict": true,
+    "outDir": "dist"
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Comments:
I was finally integrating & discovered that type definitions weren't being included in the bundle. In addition `appID` should have been nullable from the start so I updated that as well. 

Also, there was some outdated code in the README that's been updated. 

## Commits:
- f33077f Ensure type definitions get bundled.
- d9767c7 Make appID optional.
- 75d301c Update readme.
- 1bc5ffc Bump package-lock.
