### PR TITLE
build additional module version of the package

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,23 +1,63 @@
 {
-  "presets": [
-    "@babel/preset-typescript",
-    ["@babel/preset-env", {
-      "targets": {
-        "node": true
-      }
-    }],
-    "@babel/react"
-  ],
-  "plugins": [
-    ["module-resolver", {
-      "root": ["./src"],
-      "alias": {
-        "providers": "./src/providers",
-        "hooks": "./src/hooks"
-      },
-      "extensions": [".ts", ".tsx"]
-    }],
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
-  ]
+  "env": {
+    "cjs": {
+      "presets": [
+        "@babel/preset-typescript",
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "node": true
+            }
+          }
+        ],
+        "@babel/react"
+      ],
+      "plugins": [
+        [
+          "module-resolver",
+          {
+            "root": ["./src"],
+            "alias": {
+              "providers": "./src/providers",
+              "hooks": "./src/hooks"
+            },
+            "extensions": [".ts", ".tsx"]
+          }
+        ],
+        "@babel/plugin-proposal-class-properties",
+        "@babel/plugin-proposal-object-rest-spread"
+      ]
+    },
+    "module": {
+      "presets": [
+        "@babel/preset-typescript",
+        [
+          "@babel/preset-env",
+          {
+            "targets": {
+              "node": true
+            },
+            "modules": false
+          }
+        ],
+        "@babel/react"
+      ],
+      "plugins": [
+        [
+          "module-resolver",
+          {
+            "root": ["./src"],
+            "alias": {
+              "providers": "./src/providers",
+              "hooks": "./src/hooks"
+            },
+            "extensions": [".ts", ".tsx"]
+          }
+        ],
+        "@babel/plugin-proposal-class-properties",
+        "@babel/plugin-proposal-object-rest-spread"
+      ]
+    }
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "plugin:react/recommended",
     "plugin:@typescript-eslint/recommended"
   ],
-  "ignorePatterns": ["dist", "stories", "website", "node_modules"],
+  "ignorePatterns": ["dist", "module", "stories", "website", "node_modules"],
   "rules": {
     "react/prop-types": 0
   },

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 *.log
 /tmp
 /dist
+/module
 website/.next
 website/node_modules
 website/out

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Implement live chat in your react app without taking a performance hit.",
   "main": "dist/index.js",
   "module": "module/index.js",
+  "sideEffects": false,
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "version": "2.3.3",
   "description": "Implement live chat in your react app without taking a performance hit.",
   "main": "dist/index.js",
+  "module": "module/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",
-    "build": "npm run lint && tsc --emitDeclarationOnly && babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline",
+    "build": "npm run lint && tsc --emitDeclarationOnly && npm run build:cjs && npm run build:module",
+    "build:cjs": "BABEL_ENV=cjs babel src --out-dir dist --extensions \".ts,.tsx\" --source-maps inline",
+    "build:module": "BABEL_ENV=module babel src --out-dir module --extensions \".ts,.tsx\" --source-maps inline",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "dev": "tsc --noEmit --watch"

--- a/src/components/LiveChatLoaderProvider.tsx
+++ b/src/components/LiveChatLoaderProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import Providers from 'providers'
+import * as Providers from 'providers'
 import { State, Provider } from 'types'
 import { LiveChatLoaderContext } from 'context'
 

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,7 +1,7 @@
 import { useContext, useCallback, useEffect } from 'react'
 import { State } from 'types'
 import { LiveChatLoaderContext } from 'context'
-import Providers from 'providers'
+import * as Providers from 'providers'
 
 const requestIdleCallback =
   typeof window !== 'undefined' ? window.requestIdleCallback : null

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,15 +1,5 @@
-import drift from './drift'
-import helpScout from './helpScout'
-import intercom from './intercom'
-import messenger from './messenger'
-import userlike from './userlike'
-
-const providers = {
-  drift,
-  helpScout,
-  intercom,
-  messenger,
-  userlike
-}
-
-export default providers
+export { default as drift } from './drift'
+export { default as helpScout } from './helpScout'
+export { default as intercom } from './intercom'
+export { default as messenger } from './messenger'
+export { default as userlike } from './userlike'


### PR DESCRIPTION
This PR adds new build scripts to build this package as "module version", which can be consumed with webpack to allow tree-shaking. Package.json contains now additional fields, which can be used eg. by webpack to recognize different build versions.

Bundle size before this PR using Webpack 5:
![Näyttökuva 2021-5-21 kello 16 52 28](https://user-images.githubusercontent.com/23189620/119150399-14ded100-ba57-11eb-9498-681852582484.png)

Bundle size after this PR using Webpack 5:
![Näyttökuva 2021-5-21 kello 15 50 10](https://user-images.githubusercontent.com/23189620/119150450-21632980-ba57-11eb-8f07-7224691e333b.png)

This is pretty significant reduction in the output bundle considering the purpose of this package.

Disclaimer: I am rookie in tree-shaking so any additional testing is welcome.

Fixes #67 