### PR TITLE
Wait for Intercom to boot

### DIFF
--- a/src/providers/intercom.ts
+++ b/src/providers/intercom.ts
@@ -54,7 +54,12 @@ const load = ({
 }) => {
   loadScript()
   window.Intercom('boot', { app_id: providerKey })
-  setTimeout(() => setState('complete'), 2000)
+  const interval = setInterval(() => {
+    if (!window.Intercom.booted) return
+    
+    clearInterval(interval)
+    setState('complete')
+  }, 100)
 }
 
 const open = () => window.Intercom('show')


### PR DESCRIPTION
Instead of hard-coding the wait to 2s before setting the state to "complete" (where Intercom might already or might not have booted yet), check if Intercom has actually booted every 100ms.