### PR TITLE
Use relative paths for library includes

### DIFF
--- a/src/components/Chatwoot/index.tsx
+++ b/src/components/Chatwoot/index.tsx
@@ -1,5 +1,6 @@
-import useChat from 'hooks/useChat'
 import React, { CSSProperties } from 'react'
+
+import useChat from '../../hooks/useChat'
 
 const styles: {
   button: CSSProperties

--- a/src/components/Drift/index.tsx
+++ b/src/components/Drift/index.tsx
@@ -1,6 +1,7 @@
-import useChat from 'hooks/useChat'
 import React, { useState, useEffect, CSSProperties } from 'react'
-import useWindowWidth from 'hooks/useWindowWidth'
+
+import useChat from '../../hooks/useChat'
+import useWindowWidth from '../../hooks/useWindowWidth'
 
 const styles: {
   container: CSSProperties

--- a/src/components/HelpScout/index.tsx
+++ b/src/components/HelpScout/index.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, useEffect, useState } from 'react'
-import useChat from 'hooks/useChat'
-import useWindowHeight from 'hooks/useWindowHeight'
+
+import useChat from '../../hooks/useChat'
+import useWindowHeight from '../../hooks/useWindowHeight'
 
 const styles: {
   wrapper: CSSProperties

--- a/src/components/Intercom/index.tsx
+++ b/src/components/Intercom/index.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties } from 'react'
-import useChat from 'hooks/useChat'
+
+import useChat from '../../hooks/useChat'
 
 const styles: {
   wrapper: CSSProperties

--- a/src/components/LiveChatLoaderProvider.tsx
+++ b/src/components/LiveChatLoaderProvider.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
-import * as Providers from 'providers'
-import { State, Provider } from 'types'
-import { LiveChatLoaderContext } from 'context'
+import * as Providers from '../providers'
+import { State, Provider } from '../types'
+import { LiveChatLoaderContext } from '../context'
 
 export const LiveChatLoaderProvider = ({
   provider,

--- a/src/components/Messenger/index.tsx
+++ b/src/components/Messenger/index.tsx
@@ -1,7 +1,8 @@
 import React, { CSSProperties, memo } from 'react'
-import useProvider from 'hooks/useProvider'
-import useChat from 'hooks/useChat'
-import { Provider } from 'types'
+
+import { Provider } from '../../types'
+import useProvider from '../../hooks/useProvider'
+import useChat from '../../hooks/useChat'
 
 const styles: CSSProperties = {
   appearance: 'none',

--- a/src/components/Userlike/index.tsx
+++ b/src/components/Userlike/index.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties } from 'react'
-import useChat from 'hooks/useChat'
+
+import useChat from '../../hooks/useChat'
 
 const styles: {
   container: CSSProperties

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
-import { Provider, State } from 'types'
+
+import { Provider, State } from './types'
 
 interface Context {
   provider: Provider

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1,7 +1,8 @@
 import { useContext, useCallback, useEffect } from 'react'
-import { State } from 'types'
-import { LiveChatLoaderContext } from 'context'
-import * as Providers from 'providers'
+
+import { State } from '../types'
+import { LiveChatLoaderContext } from '../context'
+import * as Providers from '../providers'
 
 const requestIdleCallback =
   typeof window !== 'undefined' ? window.requestIdleCallback : null

--- a/src/hooks/useProvider.ts
+++ b/src/hooks/useProvider.ts
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
-import { Provider } from 'types'
-import { LiveChatLoaderContext } from 'context'
+
+import { Provider } from '../types'
+import { LiveChatLoaderContext } from '../context'
 
 const useProvider = (): {
   provider: Provider

--- a/src/providers/chatwoot.ts
+++ b/src/providers/chatwoot.ts
@@ -1,4 +1,4 @@
-import { State } from 'types'
+import { State } from '../types'
 import waitForLoad from '../utils/waitForLoad'
 
 const domain = 'https://app.chatwoot.com'

--- a/src/providers/drift.ts
+++ b/src/providers/drift.ts
@@ -1,4 +1,4 @@
-import { State } from 'types'
+import { State } from '../types'
 
 const domain = 'https://js.driftt.com'
 

--- a/src/providers/helpScout.ts
+++ b/src/providers/helpScout.ts
@@ -1,4 +1,4 @@
-import { State } from 'types'
+import { State } from '../types'
 
 const domain = 'https://beacon-v2.helpscout.net'
 

--- a/src/providers/intercom.ts
+++ b/src/providers/intercom.ts
@@ -1,4 +1,4 @@
-import { State } from 'types'
+import { State } from '../types'
 import waitForLoad from '../utils/waitForLoad'
 
 const domain = 'https://widget.intercom.io'

--- a/src/providers/messenger.ts
+++ b/src/providers/messenger.ts
@@ -1,4 +1,4 @@
-import { State } from 'types'
+import { State } from '../types'
 import waitForLoad from '../utils/waitForLoad'
 
 const domain = 'https://connect.facebook.net'

--- a/src/providers/userlike.ts
+++ b/src/providers/userlike.ts
@@ -1,4 +1,4 @@
-import { State } from 'types'
+import { State } from '../types'
 import waitForLoad from '../utils/waitForLoad'
 
 const domain = 'https://userlike-cdn-widgets.s3-eu-west-1.amazonaws.com'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
     "declaration": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "CommonJS",


### PR DESCRIPTION
This PR fixes #77 by removing `baseUrl` and setting all library imports as relative paths.

Looks good in VSCode now:
<img width="748" alt="Screen Shot 2021-06-08 at 12 32 48 pm" src="https://user-images.githubusercontent.com/785655/121113609-b175e100-c855-11eb-827f-79b16f3b6e6b.png">
