### PR TITLE
Fix widget stuck in open state

### DIFF
--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -88,10 +88,10 @@ const useChat = (
 
       if (open) {
         chatProvider.open()
-        setState('open')
+        if (state !== 'complete') setState('open')
       }
     },
-    []
+    [state]
   )
 
   return [state, loadChat]

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -71,7 +71,7 @@ const useChat = (
   const chatProvider = Providers[provider]
 
   const loadChat = useCallback<(args: { open: boolean }) => void>(
-    ({ open = true }) => {
+    ({ open = true } = { open: true }) => {
       if (!providerKey) {
         //eslint-disable-next-line no-console
         console.error('No api key given to react-live-chat-loader')


### PR DESCRIPTION
This PR fixes a bug where if you trigger `loadChat` (say from a contact us button) and the provider has already loaded, the fake widget will revert to the open state over the top of the loaded provider widget.

Now if you trigger `loadChat` when the provider has loaded it'll just load the provider as expected and not update the state.