### PR TITLE
Added aria-label in helpscout component

### DIFF
--- a/src/components/HelpScout/index.tsx
+++ b/src/components/HelpScout/index.tsx
@@ -208,6 +208,7 @@ const HelpScout = ({
       }}
     >
       <button
+        aria-label="Load"
         onClick={() => loadChat({ open: true })}
         onMouseEnter={() => loadChat({ open: false })}
         style={{


### PR DESCRIPTION
## What does this PR introduce?

- In order to improve accessibility, the aria-label attribute is added to the button included in the HelpScout component.

## Why the update is required?

It is a simple change, but I would really like to see this included in the main branch. I am using this library and it is really helpful to improve how helpScout is loaded. But using Lighthouse extension, the page accessibility score drops 6 points due to the lack of this attribute.

## Related issues
No

## Screenshots

No
