### PR TITLE
Add checks for chat state on provider mount

### DIFF
--- a/src/components/LiveChatLoaderProvider.tsx
+++ b/src/components/LiveChatLoaderProvider.tsx
@@ -21,7 +21,8 @@ export const LiveChatLoaderProvider = ({
   baseUrl,
   ...props
 }: LiveChatLoaderProps): JSX.Element | null => {
-  const [state, setState] = useState<State>('initial')
+  const chatProvider = Providers[provider]
+  const [state, setState] = useState<State>(chatProvider.isOpen() ? 'open' : 'initial')
   const value = {
     provider,
     idlePeriod,
@@ -31,7 +32,6 @@ export const LiveChatLoaderProvider = ({
     ...props
   }
 
-  const chatProvider = Providers[provider]
 
   if (!chatProvider) {
     //eslint-disable-next-line no-console

--- a/src/providers/chatwoot.ts
+++ b/src/providers/chatwoot.ts
@@ -83,8 +83,11 @@ const open = (): void => {
   })
 }
 
+const isOpen = () => false
+
 export default {
   domain,
   load,
-  open
+  open,
+  isOpen
 }

--- a/src/providers/drift.ts
+++ b/src/providers/drift.ts
@@ -99,8 +99,11 @@ const open = (): void =>
     api.showWelcomeMessage()
   )
 
+const isOpen = () => false
+
 export default {
   domain,
   load,
-  open
+  open,
+  isOpen
 }

--- a/src/providers/helpScout.ts
+++ b/src/providers/helpScout.ts
@@ -68,8 +68,11 @@ const load = ({
 
 const open = (): void => window.Beacon('open')
 
+const isOpen = () => false
+
 export default {
   domain,
   load,
-  open
+  open,
+  isOpen
 }

--- a/src/providers/intercom.ts
+++ b/src/providers/intercom.ts
@@ -78,8 +78,11 @@ const load = ({
 
 const open = (): void => window.Intercom('show')
 
+const isOpen = () => Boolean(typeof window !== "undefined" && window.document.querySelector('iframe[name=intercom-messenger-frame]'))
+
 export default {
   domain,
   load,
-  open
+  open,
+  isOpen
 }

--- a/src/providers/messenger.ts
+++ b/src/providers/messenger.ts
@@ -82,8 +82,11 @@ const open = (): void => {
   )
 }
 
+const isOpen = () => false
+
 export default {
   domain,
   load,
-  open
+  open,
+  isOpen
 }

--- a/src/providers/userlike.ts
+++ b/src/providers/userlike.ts
@@ -70,8 +70,11 @@ const open = (): void => {
   )
 }
 
+const isOpen = () => false
+
 export default {
   domain,
   load,
-  open
+  open,
+  isOpen
 }


### PR DESCRIPTION
👋 Hello, first off, thanks for making this project!

## What does this PR introduce?
Fixes issue where chat state gets out of sync when switching pages while using SSR.

Adds check for chat state on provider mount [see here](https://github.com/calibreapp/react-live-chat-loader/issues/68#issuecomment-852007038)

## Related issues
Are there any related [issues or feature requests](https://github.com/calibreapp/react-live-chat-loader/issues) this work will resolve? Please mention them here. e.g.:

- #68

## Notes

 - Have only added check for intercom provider
 - Needs testing on a next app
