### PR TITLE
updated the react restriction to include react 18 - tested; works fine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.7.3 - 2022-07-24
+
+- Updated package restriction to support react ^18 (@cbschuld)
+
 ### 2.7.2 - 2021-10-05
 
 - Update aria role on provider buttons to improve accessibility (@luisrudge)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/calibreapp/react-live-chat-loader.git"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
   },
   "devDependencies": {
     "@babel/cli": "^7.13.10",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/calibreapp/react-live-chat-loader.git"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.13.10",


### PR DESCRIPTION
## What does this PR introduce?

Lame and simple update to support react 18 - tested it locally and in production and appears 👍

- updates package.json requirements to allow for react 18
- fixes #137
- updates CHANGELOG as well just help speed up a release (hopefully that is helpful)