### PR TITLE
🐛 Fix invalid markup in example website

### DIFF
--- a/website/pages/chatwoot.tsx
+++ b/website/pages/chatwoot.tsx
@@ -21,9 +21,8 @@ const Page: NextPage = () => (
             </a>
             .
           </p>
-          <p>
-            View other demos: <ExampleLinks />
-          </p>
+          <p>View other demos:</p>
+          <ExampleLinks />
         </div>
       </div>
       <Chatwoot />

--- a/website/pages/drift.tsx
+++ b/website/pages/drift.tsx
@@ -18,9 +18,8 @@ const Page: NextPage = () => (
             </a>
             .
           </p>
-          <p>
-            View other demos: <ExampleLinks />
-          </p>
+          <p>View other demos:</p>
+          <ExampleLinks />
         </div>
       </div>
       <Drift icon="A" color="#0176ff" />

--- a/website/pages/helpscout.tsx
+++ b/website/pages/helpscout.tsx
@@ -21,9 +21,8 @@ const Page: NextPage = () => (
             </a>
             .
           </p>
-          <p>
-            View other demos: <ExampleLinks />
-          </p>
+          <p>View other demos:</p>
+          <ExampleLinks />
         </div>
       </div>
       <HelpScout color="#527ceb" />

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -25,9 +25,8 @@ const Page: NextPage = () => (
             Built by the team at Calibre <span>→</span>
           </a>
         </p>
-        <p>
-          View demos: <ExampleLinks />
-        </p>
+        <p>View demos:</p>
+        <ExampleLinks />
       </div>
     </div>
   </Layout>

--- a/website/pages/intercom.tsx
+++ b/website/pages/intercom.tsx
@@ -18,9 +18,8 @@ const Page: NextPage = () => (
             </a>
             .
           </p>
-          <p>
-            View other demos: <ExampleLinks />
-          </p>
+          <p>View other demos:</p>
+          <ExampleLinks />
         </div>
       </div>
       <Intercom color="#333333" />

--- a/website/pages/messenger.tsx
+++ b/website/pages/messenger.tsx
@@ -19,9 +19,8 @@ const Page: NextPage = () => (
             </a>
             .
           </p>
-          <p>
-            View other demos: <ExampleLinks />
-          </p>
+          <p>View other demos:</p>
+          <ExampleLinks />
         </div>
       </div>
       <Messenger

--- a/website/pages/userlike.tsx
+++ b/website/pages/userlike.tsx
@@ -21,9 +21,8 @@ const Page: NextPage = () => (
             </a>
             .
           </p>
-          <p>
-            View other demos: <ExampleLinks />
-          </p>
+          <p>View other demos:</p>
+          <ExampleLinks />
         </div>
       </div>
       <Userlike vOffset="47px" hOffset="49px" />


### PR DESCRIPTION
## What does this PR introduce?
Ensure `ul` elements are not children of `p` elements
