### PR TITLE
Add maxIdlePeriod

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You can pass the following props to the `LiveChatLoaderProvider` provider:
 - `idlePeriod`: How long to wait in ms before loading the provider. Default is
   `2000`. Set to `0` to never load. This value is used in a `setTimeout` in
   browsers that don't support `requestIdleCallback`.
+- `maxIdlePeriod`: Max time to wait before loading the provider in browsers that support `requestIdleCallback`. Default is `5000`ms.
 - `beforeInit`: A function to be called after the script has loaded, but before the chat provider has been initialized (optional)
 - `onReady`: A function to be called once the script has been loaded, the chat provider has been initialized and is ready for use (optional)
 

--- a/src/components/LiveChatLoaderProvider.tsx
+++ b/src/components/LiveChatLoaderProvider.tsx
@@ -7,6 +7,7 @@ interface LiveChatLoaderProps {
   provider: Provider
   children: React.ReactNode
   idlePeriod?: number
+  maxIdlePeriod?: number
   providerKey: string
   appID?: string
   baseUrl?: string
@@ -20,6 +21,7 @@ export const LiveChatLoaderProvider = ({
   provider,
   children,
   idlePeriod = 5000,
+  maxIdlePeriod = 5000,
   baseUrl,
   ...props
 }: LiveChatLoaderProps): JSX.Element | null => {
@@ -27,6 +29,7 @@ export const LiveChatLoaderProvider = ({
   const value = {
     provider,
     idlePeriod,
+    maxIdlePeriod,
     state,
     setState,
     baseUrl,

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,6 +10,7 @@ interface Context {
   appID?: string
   locale?: string
   idlePeriod?: number
+  maxIdlePeriod?: number
   baseUrl?: string
   beforeInit?: () => void
   onReady?: () => void

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -23,6 +23,7 @@ const useChat = (
     provider,
     providerKey,
     idlePeriod,
+    maxIdlePeriod,
     state,
     setState,
     appID,
@@ -65,6 +66,7 @@ const useChat = (
 
     if (requestIdleCallback) {
       requestIdleCallback(scheduleLoadChat)
+      setTimeout(() => loadChat({ open: false }), maxIdlePeriod)
     } else {
       setTimeout(() => loadChat({ open: false }), idlePeriod)
     }


### PR DESCRIPTION
Hi!

Thanks for a great package. 

This PR adds `maxIdlePeriod` that forces provider to load on browsers that support `requestIdleCallback` but do not manage to call it in reasonable time (defaults at 5s). This introduces a workaround for when the `requestIdleCallback` is never called because of infinite animations etc. 

P.S. Have this published at `@nedomas/react-live-chat-loader@2.9.2` in npm in case it takes longer to review/push new official version.