### PR TITLE
feat: remove preconnect link tag to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ You can pass the following props to the `LiveChatLoaderProvider` provider:
 - `idlePeriod`: How long to wait in ms before loading the provider. Default is
   `2000`. Set to `0` to never load. This value is used in a `setTimeout` in
   browsers that don't support `requestIdleCallback`.
-- `preconnect`: Determines whether a `link` tag with `rel=preconnect` is created. Default is `true`.
 - `beforeInit`: A function to be called after the script has loaded, but before the chat provider has been initialized (optional)
 - `onReady`: A function to be called once the script has been loaded, the chat provider has been initialized and is ready for use (optional)
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You can pass the following props to the `LiveChatLoaderProvider` provider:
 - `idlePeriod`: How long to wait in ms before loading the provider. Default is
   `2000`. Set to `0` to never load. This value is used in a `setTimeout` in
   browsers that don't support `requestIdleCallback`.
+- `preconnect`: Determines whether a `link` tag with `rel=preconnect` is created. Default is `true`.
 - `beforeInit`: A function to be called after the script has loaded, but before the chat provider has been initialized (optional)
 - `onReady`: A function to be called once the script has been loaded, the chat provider has been initialized and is ready for use (optional)
 
@@ -377,6 +378,7 @@ You can customise the Front placeholder icon by passing the following props to t
 - `containerClass`: Class to be added to the placeholder element, defaults to `live-chat-loader-placeholder`
 
 See the [official Front documentation](https://help.front.com/) for more details.
+
 </details>
 
 <details>

--- a/src/components/LiveChatLoaderProvider.tsx
+++ b/src/components/LiveChatLoaderProvider.tsx
@@ -7,6 +7,12 @@ interface LiveChatLoaderProps {
   provider: Provider
   children: React.ReactNode
   idlePeriod?: number
+  /**
+   * determines whether to create a link tag that preconnect to the chat provider's domain
+   *
+   * @default true
+   */
+  preconnect?: boolean
   providerKey: string
   appID?: string
   baseUrl?: string
@@ -20,6 +26,7 @@ export const LiveChatLoaderProvider = ({
   provider,
   children,
   idlePeriod = 5000,
+  preconnect = true,
   baseUrl,
   ...props
 }: LiveChatLoaderProps): JSX.Element | null => {
@@ -45,11 +52,13 @@ export const LiveChatLoaderProvider = ({
 
   return (
     <LiveChatLoaderContext.Provider value={value}>
-      <link
-        href={baseUrl || chatProvider.domain}
-        rel="preconnect"
-        crossOrigin=""
-      />
+      {preconnect && (
+        <link
+          href={baseUrl || chatProvider.domain}
+          rel="preconnect"
+          crossOrigin=""
+        />
+      )}
       {children}
     </LiveChatLoaderContext.Provider>
   )

--- a/src/components/LiveChatLoaderProvider.tsx
+++ b/src/components/LiveChatLoaderProvider.tsx
@@ -7,12 +7,6 @@ interface LiveChatLoaderProps {
   provider: Provider
   children: React.ReactNode
   idlePeriod?: number
-  /**
-   * determines whether to create a link tag that preconnect to the chat provider's domain
-   *
-   * @default true
-   */
-  preconnect?: boolean
   providerKey: string
   appID?: string
   baseUrl?: string
@@ -26,7 +20,6 @@ export const LiveChatLoaderProvider = ({
   provider,
   children,
   idlePeriod = 5000,
-  preconnect = true,
   baseUrl,
   ...props
 }: LiveChatLoaderProps): JSX.Element | null => {
@@ -52,13 +45,6 @@ export const LiveChatLoaderProvider = ({
 
   return (
     <LiveChatLoaderContext.Provider value={value}>
-      {preconnect && (
-        <link
-          href={baseUrl || chatProvider.domain}
-          rel="preconnect"
-          crossOrigin=""
-        />
-      )}
       {children}
     </LiveChatLoaderContext.Provider>
   )


### PR DESCRIPTION
## What does this PR introduce?

~~add a new prop to provider that determines whether the `rel=preconnect` link tag is created. I defaulted the value as `true` to make sure it's backwards compatible~~

This was an issue identified in lighthouse for my app. I set `idlePeriod={5000}`, so the preconnect is not necessary for intercom. 

![Screenshot 2024-07-16 at 11 24 04 AM](https://github.com/user-attachments/assets/829cbe01-8111-4312-a442-b9b6e57a5bb8)

from the mozilla docs https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preconnect

> The `<link rel="preconnect">` hint is best used for only the most critical connections.


## Related issues

No existing issues, just something I experienced in my own app. 

## Screenshots


![Screenshot 2024-07-16 at 11 21 45 AM](https://github.com/user-attachments/assets/35ecb6e2-e0fc-4834-b6a2-fd2b0b4fa8a0)
