### PR TITLE
chore(deps): add React 19 to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "url": "https://github.com/calibreapp/react-live-chat-loader.git"
   },
   "peerDependencies": {
-    "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.19.3",


### PR DESCRIPTION
## What does this PR introduce?

This PR adds React v19 to `peerDependencies` so that the package remains compatible with React versions 16 through 19.

## Related issues

#475
